### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol (MCP) server for reading Excel files with automatic chunking and pagination support. Built with SheetJS and TypeScript, this tool helps you handle large Excel files efficiently by automatically breaking them into manageable chunks.
 
+<a href="https://glama.ai/mcp/servers/jr2ggpdk3a"><img width="380" height="200" src="https://glama.ai/mcp/servers/jr2ggpdk3a/badge" alt="Excel Reader MCP server" /></a>
+
 ## Features
 
 - 📊 Read Excel files (.xlsx, .xls) with automatic size limits


### PR DESCRIPTION
This PR adds a badge for the [MCP Excel Reader](https://glama.ai/mcp/servers/jr2ggpdk3a) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/jr2ggpdk3a"><img width="380" height="200" src="https://glama.ai/mcp/servers/jr2ggpdk3a/badge" alt="Excel Reader MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.